### PR TITLE
Implement raw SQL execution service

### DIFF
--- a/app/services/sql_runner.py
+++ b/app/services/sql_runner.py
@@ -1,0 +1,30 @@
+import os
+import psycopg2
+import psycopg2.extras
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def run_raw_sql(query: str) -> list[dict]:
+    """Execute a raw SQL query and return results as dicts."""
+    conn = None
+    try:
+        conn = psycopg2.connect(
+            host=os.getenv("DB_HOST"),
+            database=os.getenv("DB_NAME"),
+            user=os.getenv("DB_USER"),
+            password=os.getenv("DB_PASSWORD"),
+            port=os.getenv("DB_PORT", 5432),
+        )
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(query)
+            if cur.description:
+                return cur.fetchall()
+            conn.commit()
+            return [{"status": "Query executed successfully"}]
+    except Exception as e:
+        return [{"error": str(e)}]
+    finally:
+        if conn:
+            conn.close()


### PR DESCRIPTION
## Summary
- add `run_raw_sql` service using psycopg2

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875d9015ba4832a844c3373fd53a13c