### PR TITLE
Add /query endpoint for raw SQL

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,1 @@
+# API package

--- a/app/api/routes/query.py
+++ b/app/api/routes/query.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.query import QueryRequest, QueryResponse
+from app.services.sql_runner import run_raw_sql
+
+router = APIRouter()
+
+
+@router.post("/query", response_model=QueryResponse)
+def query_runner(payload: QueryRequest) -> QueryResponse:
+    """Execute raw SQL provided in the request body."""
+
+    result = run_raw_sql(payload.sql)
+    if result and isinstance(result, list) and "error" in result[0]:
+        raise HTTPException(status_code=400, detail=result[0]["error"])
+    return QueryResponse(result=result)

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,10 @@
 from fastapi import FastAPI
 
+from app.api.routes import query
+
 app = FastAPI()
+
+app.include_router(query.router, prefix="/api")
 
 @app.get("/")
 def read_root():

--- a/app/schemas/query.py
+++ b/app/schemas/query.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class QueryRequest(BaseModel):
+    """Request body for executing raw SQL queries."""
+
+    sql: str
+
+
+class QueryResponse(BaseModel):
+    """Response containing query execution results."""
+
+    result: list[dict]


### PR DESCRIPTION
## Summary
- create `QueryRequest` and `QueryResponse` schemas
- implement `/api/query` route for running raw SQL
- register new query router in `main.py`
- ensure API module is recognized

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6875ddc24954832abb135ed70a4c36d8