### PR TITLE
Add centralized Pydantic settings

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,19 @@
+import os
+from pydantic import BaseSettings
+from functools import lru_cache
+
+
+class Settings(BaseSettings):
+    DB_HOST: str
+    DB_PORT: int
+    DB_NAME: str
+    DB_USER: str
+    DB_PASSWORD: str
+
+    class Config:
+        env_file = ".env"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/app/services/sql_runner.py
+++ b/app/services/sql_runner.py
@@ -1,9 +1,8 @@
-import os
 import psycopg2
 import psycopg2.extras
-from dotenv import load_dotenv
+from app.core.config import get_settings
 
-load_dotenv()
+settings = get_settings()
 
 
 def run_raw_sql(query: str) -> list[dict]:
@@ -11,11 +10,11 @@ def run_raw_sql(query: str) -> list[dict]:
     conn = None
     try:
         conn = psycopg2.connect(
-            host=os.getenv("DB_HOST"),
-            database=os.getenv("DB_NAME"),
-            user=os.getenv("DB_USER"),
-            password=os.getenv("DB_PASSWORD"),
-            port=os.getenv("DB_PORT", 5432),
+            host=settings.DB_HOST,
+            database=settings.DB_NAME,
+            user=settings.DB_USER,
+            password=settings.DB_PASSWORD,
+            port=settings.DB_PORT,
         )
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(query)


### PR DESCRIPTION
## Summary
- centralize environment config using Pydantic
- load `.env` values once via `get_settings`
- use the settings object inside SQL runner

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875df0ad654832a87a99d54f5227e1d