### PR TITLE
Add test for SQL runner

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,8 @@
 import os
-from pydantic import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:  # pragma: no cover - fallback for pydantic v1
+    from pydantic import BaseSettings
 from functools import lru_cache
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 psycopg2-binary
 python-dotenv
 alembic
+pytest

--- a/tests/test_sql_runner.py
+++ b/tests/test_sql_runner.py
@@ -1,0 +1,18 @@
+from app.services.sql_runner import run_raw_sql
+
+
+def test_run_raw_sql():
+    create = run_raw_sql(
+        "CREATE TABLE IF NOT EXISTS test_table (id SERIAL PRIMARY KEY, name TEXT);"
+    )
+    assert isinstance(create, list)
+
+    insert = run_raw_sql("INSERT INTO test_table (name) VALUES ('Dez');")
+    assert insert == [{"status": "Query executed successfully"}]
+
+    select = run_raw_sql("SELECT * FROM test_table;")
+    assert isinstance(select, list)
+    assert select[0]["name"] == "Dez"
+
+    drop = run_raw_sql("DROP TABLE test_table;")
+    assert drop == [{"status": "Query executed successfully"}]


### PR DESCRIPTION
## Summary
- add a unit test verifying SQL runner works
- update config for `pydantic-settings` fallback
- include pytest in requirements

## Testing
- `PYTHONPATH=. pytest tests/test_sql_runner.py -q` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_6875e055e318832aaf61774d76d31f3f