### PR TITLE
Add OpenAI assistant client with SQL execution

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,6 @@ DB_PORT=5432
 DB_NAME=mapquery
 DB_USER=postgres
 DB_PASSWORD=password123
+
+OPENAI_API_KEY=sk-placeholder
+OPENAI_ASSISTANT_ID=asst-placeholder

--- a/app/agents/assistant_client.py
+++ b/app/agents/assistant_client.py
@@ -1,0 +1,36 @@
+import openai
+from app.core.config import get_settings
+
+settings = get_settings()
+openai.api_key = settings.OPENAI_API_KEY
+
+
+def get_sql_from_natural_language(message: str, thread_id: str | None = None) -> dict:
+    try:
+        if not thread_id:
+            thread = openai.beta.threads.create()
+            thread_id = thread.id
+
+        openai.beta.threads.messages.create(
+            thread_id=thread_id,
+            role="user",
+            content=message,
+        )
+
+        run = openai.beta.threads.runs.create(
+            thread_id=thread_id,
+            assistant_id=settings.OPENAI_ASSISTANT_ID,
+        )
+
+        while True:
+            run_status = openai.beta.threads.runs.retrieve(thread_id, run.id)
+            if run_status.status == "completed":
+                break
+
+        messages = openai.beta.threads.messages.list(thread_id)
+        latest = messages.data[0].content[0].text.value
+
+        return {"sql": latest, "thread_id": thread_id}
+
+    except Exception as e:
+        return {"error": str(e)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv
 alembic
 pytest
 pydantic-settings
+openai


### PR DESCRIPTION
## Summary
- create `assistant_client` for OpenAI Assistant threads
- simplify agent route to translate NL -> SQL and execute
- add OpenAI placeholders in `.env`
- include openai in requirements

## Testing
- `PYTHONPATH=. pytest -q` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_6875f096ac44832a91cd37f3e1b9e66d