### PR TITLE
Implement natural language response formatter

### DIFF
--- a/app/api/routes/agent.py
+++ b/app/api/routes/agent.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException
 from app.schemas.agent import AgentQuery
 from app.agents.assistant_client import get_sql_from_natural_language
 from app.services.sql_runner import run_raw_sql
+from app.services.response_formatter import format_natural_language_response
 
 router = APIRouter()
 
@@ -44,4 +45,10 @@ def query_agent(payload: AgentQuery):
             "thread_id": thread_id,
         }
 
-    return {"result": result, "thread_id": thread_id, "sql": sql}
+    natural = format_natural_language_response(payload.message, result)
+    return {
+        "natural_response": natural,
+        "thread_id": thread_id,
+        "sql": sql,
+        "raw_result": result,
+    }

--- a/app/services/response_formatter.py
+++ b/app/services/response_formatter.py
@@ -1,0 +1,24 @@
+"""Utilities for formatting database query results into natural language."""
+
+from typing import List, Dict
+
+
+def format_natural_language_response(original_query: str, result: List[Dict]) -> str:
+    """Summarize a SQL query result into a short natural language sentence."""
+    if not result:
+        return "There were no results matching your request."
+
+    if isinstance(result[0], dict) and ("count" in result[0] or "total" in result[0]):
+        key = "count" if "count" in result[0] else "total"
+        value = result[0][key]
+        return f"There are {value} results matching your request."
+
+    if len(result) == 1 and len(result[0]) == 1:
+        only_value = list(result[0].values())[0]
+        return f"The result is: {only_value}."
+
+    preview = result[:5]
+    items = [", ".join(f"{k}: {v}" for k, v in row.items()) for row in preview]
+    return (
+        f"There are {len(result)} results. Here is a sample: " + "; ".join(items)
+    )


### PR DESCRIPTION
## Summary
- add `format_natural_language_response` to turn SQL results into plain text
- update agent query route to return natural responses alongside SQL output

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687873e283e0832a89fcda9c421db906