### PR TITLE
Add property management models and seeder

### DIFF
--- a/alembic/versions/202407061201_init_models.py
+++ b/alembic/versions/202407061201_init_models.py
@@ -1,0 +1,104 @@
+"""init models
+
+Revision ID: 202407061201
+Revises: 
+Create Date: 2024-07-06 12:01:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '202407061201'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'properties',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String, nullable=False),
+        sa.Column('address', sa.String, nullable=False),
+        sa.Column('unit_count', sa.Integer, nullable=False),
+    )
+
+    unitsize = sa.Enum('STUDIO', '1BR', '2BR', '3BR', name='unitsize')
+    unitsize.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        'apartment_units',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('unit_number', sa.String, nullable=False),
+        sa.Column('size', unitsize, nullable=False),
+        sa.Column('rent', sa.Integer, nullable=False),
+        sa.Column('property_id', sa.Integer, sa.ForeignKey('properties.id'), nullable=False),
+    )
+
+    op.create_table(
+        'residents',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('full_name', sa.String, nullable=False),
+        sa.Column('email', sa.String, nullable=False, unique=True),
+        sa.Column('phone', sa.String, nullable=False),
+        sa.Column('income', sa.Integer),
+        sa.Column('occupation', sa.String),
+        sa.Column('num_occupants', sa.Integer, nullable=False, server_default='1'),
+        sa.Column('unit_id', sa.Integer, sa.ForeignKey('apartment_units.id'), nullable=False),
+    )
+
+    paymentstatus = sa.Enum('ON_TIME', 'LATE', 'OUTSTANDING', name='paymentstatus')
+    paymentstatus.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        'payments',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('amount', sa.Float, nullable=False),
+        sa.Column('date', sa.Date, nullable=False),
+        sa.Column('status', paymentstatus, nullable=False),
+        sa.Column('resident_id', sa.Integer, sa.ForeignKey('residents.id'), nullable=False),
+    )
+
+    repairstatus = sa.Enum('NEW', 'IN_PROGRESS', 'DONE', name='repairstatus')
+    repairstatus.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        'repairs',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('description', sa.String, nullable=False),
+        sa.Column('status', repairstatus, nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True)),
+        sa.Column('unit_id', sa.Integer, sa.ForeignKey('apartment_units.id'), nullable=False),
+        sa.Column('resident_id', sa.Integer, sa.ForeignKey('residents.id')),    )
+
+    op.create_table(
+        'pets',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('type', sa.String, nullable=False),
+        sa.Column('breed', sa.String),
+        sa.Column('weight', sa.Float),
+        sa.Column('resident_id', sa.Integer, sa.ForeignKey('residents.id'), nullable=False),
+    )
+
+    op.create_table(
+        'vehicles',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('make', sa.String, nullable=False),
+        sa.Column('model', sa.String, nullable=False),
+        sa.Column('plate', sa.String, nullable=False),
+        sa.Column('resident_id', sa.Integer, sa.ForeignKey('residents.id'), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('vehicles')
+    op.drop_table('pets')
+    op.drop_table('repairs')
+    op.drop_table('payments')
+    op.drop_table('residents')
+    op.drop_table('apartment_units')
+    op.drop_table('properties')
+    sa.Enum(name='unitsize').drop(op.get_bind(), checkfirst=False)
+    sa.Enum(name='paymentstatus').drop(op.get_bind(), checkfirst=False)
+    sa.Enum(name='repairstatus').drop(op.get_bind(), checkfirst=False)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,8 +17,8 @@ class Settings(BaseSettings):
         return f"postgresql://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
     
     # OpenAI settings
-    OPENAI_API_KEY: str
-    OPENAI_ASSISTANT_ID: str  # ID of the SQL-specialized assistant
+    OPENAI_API_KEY: str = "dummy"
+    OPENAI_ASSISTANT_ID: str = "dummy"  # ID of the SQL-specialized assistant
     OPENAI_REQUEST_TIMEOUT: int = 120  # Timeout for OpenAI API requests in seconds (2 minutes)
     OPENAI_MAX_RETRIES: int = 5  # Maximum number of retries for OpenAI API calls
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,20 @@
+from .property import Property
+from .unit import ApartmentUnit, UnitSize
+from .resident import Resident
+from .payment import Payment, PaymentStatus
+from .repair import Repair, RepairStatus
+from .pet import Pet
+from .vehicle import Vehicle
+
+__all__ = [
+    "Property",
+    "ApartmentUnit",
+    "UnitSize",
+    "Resident",
+    "Payment",
+    "PaymentStatus",
+    "Repair",
+    "RepairStatus",
+    "Pet",
+    "Vehicle",
+]

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, Integer, Float, Date, Enum, ForeignKey
+from sqlalchemy.orm import relationship
+import enum
+
+from app.db.models import Base
+
+
+class PaymentStatus(str, enum.Enum):
+    ON_TIME = "ON_TIME"
+    LATE = "LATE"
+    OUTSTANDING = "OUTSTANDING"
+
+
+class Payment(Base):
+    __tablename__ = "payments"
+
+    id = Column(Integer, primary_key=True)
+    amount = Column(Float, nullable=False)
+    date = Column(Date, nullable=False)
+    status = Column(Enum(PaymentStatus, name="paymentstatus"), nullable=False)
+    resident_id = Column(Integer, ForeignKey("residents.id"), nullable=False)
+
+    resident = relationship("Resident", back_populates="payments")

--- a/app/models/pet.py
+++ b/app/models/pet.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, Float, ForeignKey
+from sqlalchemy.orm import relationship
+
+from app.db.models import Base
+
+
+class Pet(Base):
+    __tablename__ = "pets"
+
+    id = Column(Integer, primary_key=True)
+    type = Column(String, nullable=False)
+    breed = Column(String, nullable=True)
+    weight = Column(Float, nullable=True)
+    resident_id = Column(Integer, ForeignKey("residents.id"), nullable=False)
+
+    resident = relationship("Resident", back_populates="pets")

--- a/app/models/property.py
+++ b/app/models/property.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+
+from app.db.models import Base
+
+
+class Property(Base):
+    __tablename__ = "properties"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    address = Column(String, nullable=False)
+    unit_count = Column(Integer, nullable=False)
+
+    units = relationship("ApartmentUnit", back_populates="property")

--- a/app/models/repair.py
+++ b/app/models/repair.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, Integer, String, Enum, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+import enum
+
+from app.db.models import Base
+
+
+class RepairStatus(str, enum.Enum):
+    NEW = "NEW"
+    IN_PROGRESS = "IN_PROGRESS"
+    DONE = "DONE"
+
+
+class Repair(Base):
+    __tablename__ = "repairs"
+
+    id = Column(Integer, primary_key=True)
+    description = Column(String, nullable=False)
+    status = Column(Enum(RepairStatus, name="repairstatus"), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+    unit_id = Column(Integer, ForeignKey("apartment_units.id"), nullable=False)
+    resident_id = Column(Integer, ForeignKey("residents.id"), nullable=True)
+
+    unit = relationship("ApartmentUnit", back_populates="repairs")
+    resident = relationship("Resident", back_populates="repairs")

--- a/app/models/resident.py
+++ b/app/models/resident.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from app.db.models import Base
+
+
+class Resident(Base):
+    __tablename__ = "residents"
+
+    id = Column(Integer, primary_key=True)
+    full_name = Column(String, nullable=False)
+    email = Column(String, nullable=False, unique=True)
+    phone = Column(String, nullable=False)
+    income = Column(Integer, nullable=True)
+    occupation = Column(String, nullable=True)
+    num_occupants = Column(Integer, nullable=False, default=1)
+    unit_id = Column(Integer, ForeignKey("apartment_units.id"), nullable=False)
+
+    unit = relationship("ApartmentUnit", back_populates="residents")
+    payments = relationship("Payment", back_populates="resident")
+    pets = relationship("Pet", back_populates="resident")
+    vehicles = relationship("Vehicle", back_populates="resident")
+    repairs = relationship("Repair", back_populates="resident")

--- a/app/models/unit.py
+++ b/app/models/unit.py
@@ -1,0 +1,26 @@
+from sqlalchemy import Column, Integer, String, Enum, ForeignKey
+from sqlalchemy.orm import relationship
+import enum
+
+from app.db.models import Base
+
+
+class UnitSize(str, enum.Enum):
+    STUDIO = "STUDIO"
+    ONE_BED = "1BR"
+    TWO_BED = "2BR"
+    THREE_BED = "3BR"
+
+
+class ApartmentUnit(Base):
+    __tablename__ = "apartment_units"
+
+    id = Column(Integer, primary_key=True)
+    unit_number = Column(String, nullable=False)
+    size = Column(Enum(UnitSize, name="unitsize"), nullable=False)
+    rent = Column(Integer, nullable=False)
+    property_id = Column(Integer, ForeignKey("properties.id"), nullable=False)
+
+    property = relationship("Property", back_populates="units")
+    residents = relationship("Resident", back_populates="unit")
+    repairs = relationship("Repair", back_populates="unit")

--- a/app/models/vehicle.py
+++ b/app/models/vehicle.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from app.db.models import Base
+
+
+class Vehicle(Base):
+    __tablename__ = "vehicles"
+
+    id = Column(Integer, primary_key=True)
+    make = Column(String, nullable=False)
+    model = Column(String, nullable=False)
+    plate = Column(String, nullable=False)
+    resident_id = Column(Integer, ForeignKey("residents.id"), nullable=False)
+
+    resident = relationship("Resident", back_populates="vehicles")

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,3 +1,41 @@
 from .agent import AgentQuery
+from .property import PropertyBase, PropertyCreate, PropertyRead
+from .unit import (
+    ApartmentUnitBase,
+    ApartmentUnitCreate,
+    ApartmentUnitRead,
+    UnitSize,
+)
+from .resident import ResidentBase, ResidentCreate, ResidentRead
+from .payment import PaymentBase, PaymentCreate, PaymentRead, PaymentStatus
+from .repair import RepairBase, RepairCreate, RepairRead, RepairStatus
+from .pet import PetBase, PetCreate, PetRead
+from .vehicle import VehicleBase, VehicleCreate, VehicleRead
 
-__all__ = ['AgentQuery']
+__all__ = [
+    "AgentQuery",
+    "PropertyBase",
+    "PropertyCreate",
+    "PropertyRead",
+    "ApartmentUnitBase",
+    "ApartmentUnitCreate",
+    "ApartmentUnitRead",
+    "UnitSize",
+    "ResidentBase",
+    "ResidentCreate",
+    "ResidentRead",
+    "PaymentBase",
+    "PaymentCreate",
+    "PaymentRead",
+    "PaymentStatus",
+    "RepairBase",
+    "RepairCreate",
+    "RepairRead",
+    "RepairStatus",
+    "PetBase",
+    "PetCreate",
+    "PetRead",
+    "VehicleBase",
+    "VehicleCreate",
+    "VehicleRead",
+]

--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel
+from enum import Enum
+from datetime import date
+
+
+class PaymentStatus(str, Enum):
+    ON_TIME = "ON_TIME"
+    LATE = "LATE"
+    OUTSTANDING = "OUTSTANDING"
+
+
+class PaymentBase(BaseModel):
+    amount: float
+    date: date
+    status: PaymentStatus
+    resident_id: int
+
+
+class PaymentCreate(PaymentBase):
+    pass
+
+
+class PaymentRead(PaymentBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/pet.py
+++ b/app/schemas/pet.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class PetBase(BaseModel):
+    type: str
+    breed: str | None = None
+    weight: float | None = None
+    resident_id: int
+
+
+class PetCreate(PetBase):
+    pass
+
+
+class PetRead(PetBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/property.py
+++ b/app/schemas/property.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class PropertyBase(BaseModel):
+    name: str
+    address: str
+    unit_count: int
+
+
+class PropertyCreate(PropertyBase):
+    pass
+
+
+class PropertyRead(PropertyBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/repair.py
+++ b/app/schemas/repair.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel
+from enum import Enum
+from datetime import datetime
+
+
+class RepairStatus(str, Enum):
+    NEW = "NEW"
+    IN_PROGRESS = "IN_PROGRESS"
+    DONE = "DONE"
+
+
+class RepairBase(BaseModel):
+    description: str
+    status: RepairStatus
+    unit_id: int
+    resident_id: int | None = None
+
+
+class RepairCreate(RepairBase):
+    pass
+
+
+class RepairRead(RepairBase):
+    id: int
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/resident.py
+++ b/app/schemas/resident.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+
+
+class ResidentBase(BaseModel):
+    full_name: str
+    email: str
+    phone: str
+    income: int | None = None
+    occupation: str | None = None
+    num_occupants: int
+    unit_id: int
+
+
+class ResidentCreate(ResidentBase):
+    pass
+
+
+class ResidentRead(ResidentBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/unit.py
+++ b/app/schemas/unit.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel
+from enum import Enum
+
+
+class UnitSize(str, Enum):
+    STUDIO = "STUDIO"
+    ONE_BED = "1BR"
+    TWO_BED = "2BR"
+    THREE_BED = "3BR"
+
+
+class ApartmentUnitBase(BaseModel):
+    unit_number: str
+    size: UnitSize
+    rent: int
+    property_id: int
+
+
+class ApartmentUnitCreate(ApartmentUnitBase):
+    pass
+
+
+class ApartmentUnitRead(ApartmentUnitBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/vehicle.py
+++ b/app/schemas/vehicle.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class VehicleBase(BaseModel):
+    make: str
+    model: str
+    plate: str
+    resident_id: int
+
+
+class VehicleCreate(VehicleBase):
+    pass
+
+
+class VehicleRead(VehicleBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -1,0 +1,145 @@
+"""Seed demo data for properties, units, residents and related models."""
+import random
+from datetime import date, timedelta
+import psycopg2
+from psycopg2.extras import DictCursor
+
+PROPERTIES = [
+    {"name": "Maple Apartments", "address": "100 Maple St"},
+    {"name": "Oak Residences", "address": "200 Oak Ave"},
+    {"name": "Pine Condos", "address": "300 Pine Rd"},
+]
+
+FIRST_NAMES = ["Alex", "Sam", "Jordan", "Taylor", "Casey", "Drew", "Morgan", "Jamie", "Robin", "Dez"]
+LAST_NAMES = ["Smith", "Johnson", "Lee", "Brown", "Garcia", "Martinez", "Davis", "Lopez", "Clark", "Lewis"]
+OCCUPATIONS = ["Engineer", "Teacher", "Designer", "Nurse", "Developer", "Manager", "Analyst"]
+PET_TYPES = ["Dog", "Cat", "Bird", "Fish"]
+VEHICLE_MAKES = ["Toyota", "Honda", "Ford", "Tesla"]
+VEHICLE_MODELS = ["Sedan", "SUV", "Truck", "Coupe"]
+
+
+def rand_name() -> str:
+    return f"{random.choice(FIRST_NAMES)} {random.choice(LAST_NAMES)}"
+
+
+def main():
+    conn = psycopg2.connect(
+        host="db",
+        database="mapquery",
+        user="postgres",
+        password="postgres",
+        port=5432,
+    )
+    try:
+        with conn.cursor(cursor_factory=DictCursor) as cur:
+            # Clear existing data
+            cur.execute(
+                "TRUNCATE vehicles, pets, repairs, payments, residents, apartment_units, properties RESTART IDENTITY CASCADE"
+            )
+
+            # Insert properties
+            for prop in PROPERTIES:
+                cur.execute(
+                    "INSERT INTO properties (name, address, unit_count) VALUES (%s, %s, %s) RETURNING id",
+                    (prop["name"], prop["address"], 4),
+                )
+                prop["id"] = cur.fetchone()[0]
+
+            # Insert units
+            unit_sizes = ["STUDIO", "1BR", "2BR", "3BR"]
+            unit_ids = []
+            for prop in PROPERTIES:
+                for i in range(1, 5):
+                    unit_number = f"{prop['name'][0]}-{i}"
+                    size = random.choice(unit_sizes)
+                    rent = random.randint(800, 2500)
+                    cur.execute(
+                        """
+                        INSERT INTO apartment_units (unit_number, size, rent, property_id)
+                        VALUES (%s, %s, %s, %s) RETURNING id
+                        """,
+                        (unit_number, size, rent, prop["id"]),
+                    )
+                    unit_ids.append(cur.fetchone()[0])
+
+            # Insert residents
+            resident_ids = []
+            for _ in range(30):
+                name = rand_name()
+                email = f"{name.replace(' ', '.').lower()}@example.com"
+                phone = f"555-{random.randint(1000,9999)}"
+                income = random.randint(30000, 120000)
+                occupation = random.choice(OCCUPATIONS)
+                num_occupants = random.randint(1, 4)
+                unit_id = random.choice(unit_ids)
+                cur.execute(
+                    """
+                    INSERT INTO residents (full_name, email, phone, income, occupation, num_occupants, unit_id)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s) RETURNING id
+                    """,
+                    (name, email, phone, income, occupation, num_occupants, unit_id),
+                )
+                resident_ids.append(cur.fetchone()[0])
+
+            # Insert pets
+            for _ in range(15):
+                resident_id = random.choice(resident_ids)
+                pet_type = random.choice(PET_TYPES)
+                breed = random.choice(["Mix", "Purebred", ""])
+                weight = random.uniform(5, 80)
+                cur.execute(
+                    "INSERT INTO pets (type, breed, weight, resident_id) VALUES (%s, %s, %s, %s)",
+                    (pet_type, breed, weight, resident_id),
+                )
+
+            # Insert vehicles
+            for _ in range(20):
+                resident_id = random.choice(resident_ids)
+                make = random.choice(VEHICLE_MAKES)
+                model = random.choice(VEHICLE_MODELS)
+                plate = f"{random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZ')}{random.randint(1000,9999)}"
+                cur.execute(
+                    "INSERT INTO vehicles (make, model, plate, resident_id) VALUES (%s, %s, %s, %s)",
+                    (make, model, plate, resident_id),
+                )
+
+            # Insert payments
+            num_payments = random.randint(30, 50)
+            statuses = ["ON_TIME", "LATE", "OUTSTANDING"]
+            for _ in range(num_payments):
+                resident_id = random.choice(resident_ids)
+                amount = random.randint(800, 2500)
+                days_ago = random.randint(0, 60)
+                pay_date = date.today() - timedelta(days=days_ago)
+                status = random.choices(statuses, weights=[0.7, 0.2, 0.1])[0]
+                cur.execute(
+                    """
+                    INSERT INTO payments (amount, date, status, resident_id)
+                    VALUES (%s, %s, %s, %s)
+                    """,
+                    (amount, pay_date, status, resident_id),
+                )
+
+            # Insert repairs
+            open_statuses = ["NEW", "IN_PROGRESS"]
+            for _ in range(8):
+                unit_id = random.choice(unit_ids)
+                resident_id = random.choice(resident_ids)
+                desc = random.choice(["Leaky faucet", "Broken heater", "Window crack", "Appliance issue"])
+                status = random.choice(open_statuses)
+                cur.execute(
+                    """
+                    INSERT INTO repairs (description, status, unit_id, resident_id)
+                    VALUES (%s, %s, %s, %s)
+                    """,
+                    (desc, status, unit_id, resident_id),
+                )
+
+            conn.commit()
+            print("Demo data inserted successfully!")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- define Property, ApartmentUnit, Resident, Payment, Repair, Pet, and Vehicle models
- create matching Pydantic schemas
- add Alembic migration for new tables
- include seed_demo_data.py for mock dataset
- allow default OpenAI settings in `Settings`

## Testing
- `apt-get update`
- `apt-get install -y postgresql`
- `service postgresql start`
- `sudo -u postgres psql -c "CREATE DATABASE mapquery;"`
- `sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687877b3a098832ab4aec44c251357e5